### PR TITLE
Enabled Copy button extension & code highlighting for python and yaml files

### DIFF
--- a/Chapter2/section_two.rst
+++ b/Chapter2/section_two.rst
@@ -14,8 +14,8 @@ This section discusses the data required to run the Roth C model.
 - Clay content of the soil: This parameter is expressed in percentage. The clay content calculates how much water topsoil can hold.
 - An estimate of the decomposability of the incoming plant material - the DPM/RPM ratio. 
 - Soil cover: The soil cover parameter tells if the soil is bare or vegetated in a specific month.
-- Monthly input of plant residues. The plant residue can be explained as the amount of carbon ingested by the soil per month. This parameter is measured in t C ha-1. To help generate the value of these input parameters, the Roth C model runs in 'inverse' mode, which infers that it generates its input from known soil and weather data.
-- Monthly input of farmyard manure. This parameter is measured in t C ha-1 . This parameter is input separately because it is treated differently from inputs of fresh plant residues. The amount of farmyard manure in the soil also referred to as FYM, is not a required parameter.
+- Monthly input of plant residues. The plant residue can be explained as the amount of carbon ingested by the soil per month. This parameter is measured in t C ha :sup:`-1`. To help generate the value of these input parameters, the Roth C model runs in 'inverse' mode, which infers that it generates its input from known soil and weather data.
+- Monthly input of farmyard manure. This parameter is measured in t C ha :sup:`-1` . This parameter is input separately because it is treated differently from inputs of fresh plant residues. The amount of farmyard manure in the soil also referred to as FYM, is not a required parameter.
 - Depth of soil layer. This parameter is measured in centimeters (cm).
 
 **Chapman Richards Forest Model**

--- a/Chapter2/section_two.rst
+++ b/Chapter2/section_two.rst
@@ -14,8 +14,8 @@ This section discusses the data required to run the Roth C model.
 - Clay content of the soil: This parameter is expressed in percentage. The clay content calculates how much water topsoil can hold.
 - An estimate of the decomposability of the incoming plant material - the DPM/RPM ratio. 
 - Soil cover: The soil cover parameter tells if the soil is bare or vegetated in a specific month.
-- Monthly input of plant residues. The plant residue can be explained as the amount of carbon ingested by the soil per month. This parameter is measured in t C ha :sup:`-1`. To help generate the value of these input parameters, the Roth C model runs in 'inverse' mode, which infers that it generates its input from known soil and weather data.
-- Monthly input of farmyard manure. This parameter is measured in t C ha :sup:`-1` . This parameter is input separately because it is treated differently from inputs of fresh plant residues. The amount of farmyard manure in the soil also referred to as FYM, is not a required parameter.
+- Monthly input of plant residues. The plant residue can be explained as the amount of carbon ingested by the soil per month. This parameter is measured in t C ha-1. To help generate the value of these input parameters, the Roth C model runs in 'inverse' mode, which infers that it generates its input from known soil and weather data.
+- Monthly input of farmyard manure. This parameter is measured in t C ha-1 . This parameter is input separately because it is treated differently from inputs of fresh plant residues. The amount of farmyard manure in the soil also referred to as FYM, is not a required parameter.
 - Depth of soil layer. This parameter is measured in centimeters (cm).
 
 **Chapman Richards Forest Model**

--- a/Chapter4/section_one.rst
+++ b/Chapter4/section_one.rst
@@ -63,7 +63,7 @@ We can see the different options specified in the code block above.
 The project’s root directory has a ``dvc.yaml`` file. This ``dvc.yaml``
 file contains an established DVC pipeline.
 
-.. code:: python
+.. code:: yaml
 
 
     vars:

--- a/Chapter4/section_one.rst
+++ b/Chapter4/section_one.rst
@@ -24,7 +24,7 @@ that takes the raw ``HarmonizedWorldSoilDatabase`` dataset as a
 parameter and then converts the dataset from a ``.bil`` file to a
 ``.tif`` file. The ``BILtoTIF`` function then saves the ``.tif`` file.
 
-.. code:: py
+.. code:: python
 
       def BILtoTIF(inBilPath,outTifPath):
           inBil = gdal.Open(inBilPath)
@@ -38,7 +38,7 @@ Next, in the ``Data/Soil/bilToTif.py`` file, we have a
 ``restructureTIF`` function that restructures the ``.tif`` dataset using
 the options specified in the ``restructureTIF``.
 
-.. code:: py
+.. code:: python
 
       def restructureTIF(in_tif, out_tif):
             options = gdal.WarpOptions(
@@ -63,7 +63,7 @@ We can see the different options specified in the code block above.
 The project’s root directory has a ``dvc.yaml`` file. This ``dvc.yaml``
 file contains an established DVC pipeline.
 
-.. code:: py
+.. code:: python
 
 
     vars:
@@ -91,7 +91,7 @@ In the root directory, there is a ``.github`` folder that contains a
 The ``github/workflows/health-check.yaml`` file holds the GitHub Actions
 responsible for recreating this DVC pipeline.
 
-.. code:: py
+.. code:: yaml
 
 
    name: dvc-report

--- a/Chapter5/section_four.rst
+++ b/Chapter5/section_four.rst
@@ -33,7 +33,7 @@ The bounding box in the code block above receives three parameters:
 
 Replace the bounding box with the code block below.
 
-.. code:: py
+.. code:: python
 
        bbox = BoundingBox(
            VectorLayer(
@@ -54,7 +54,7 @@ The classifier layers are shown in the image below.
 
 Replace the classifier layers with this code block below.
 
-.. code:: py
+.. code:: python
 
        classifier_layers = [
                    VectorLayer("LdSpp", os.path.join(layer_root, "inventory", "inv_sample.shp"), Attribute("LdSpp"), tags=[classifier_tag]),
@@ -77,7 +77,7 @@ the age layer in the image below.
 
 We replace the age layer with this piece of code.
 
-.. code:: py
+.. code:: python
 
        # Age - layer name must be "initial_age" so that the script can update the GCBM configuration file.
                VectorLayer("initial_age", os.path.join(layer_root, "inventory", "inv_sample.shp"), Attribute("Age"),
@@ -92,7 +92,7 @@ annual temperature vector layer.
 
 The vector layer is replaced by this raster layer.
 
-.. code:: py
+.. code:: python
 
        RasterLayer(os.path.join(layer_root, "environment", "NAmerica_MAT_1971_2000.tif"), 
              name= "mean_annual_temperature"),

--- a/conf.py
+++ b/conf.py
@@ -28,6 +28,7 @@ author = 'Amarachi Iheanacho'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_copybutton'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Fixes issue #29 
- Enabled the copy button extension 
- updated the shortname for python code 
- updated the shortname for yaml code 
![Screenshot from 2023-02-27 01-51-04](https://user-images.githubusercontent.com/92504666/221435092-1d28da07-b383-49d2-9046-56d9bd0915a8.png)
